### PR TITLE
xioctl: Use proper size for request argument

### DIFF
--- a/ext/v4l2/camera.c
+++ b/ext/v4l2/camera.c
@@ -61,7 +61,7 @@
 #define ST_STOPPING               (6)
 #define ST_FINALIZED              (7)
 
-static int xioctl(int fh, int request, void *arg)
+static int xioctl(int fh, unsigned long request, void *arg)
 {
   int r;
 


### PR DESCRIPTION
This was causing the request to get truncated on certain video
ioctls on OpenBSD.