### PR TITLE
OpenBSD support

### DIFF
--- a/ext/v4l2/camera.c
+++ b/ext/v4l2/camera.c
@@ -154,7 +154,7 @@ set_format(int fd, uint32_t fcc, int wd, int ht)
   fmt.fmt.pix.width       = wd;
   fmt.fmt.pix.height      = ht;
   fmt.fmt.pix.pixelformat = fcc;
-  fmt.fmt.pix.field       = V4L2_FIELD_INTERLACED;
+  fmt.fmt.pix.field       = V4L2_FIELD_ANY;
 
   err = xioctl(fd, VIDIOC_S_FMT, &fmt);
   if (err < 0) {
@@ -1378,7 +1378,7 @@ camera_check_busy(camera_t* cam, int* busy)
     fmt.fmt.pix.width       = cam->width;
     fmt.fmt.pix.height      = cam->height;
     fmt.fmt.pix.pixelformat = cam->format;
-    fmt.fmt.pix.field       = V4L2_FIELD_INTERLACED;
+    fmt.fmt.pix.field       = V4L2_FIELD_ANY;
 
     err = xioctl(cam->fd, VIDIOC_S_FMT, &fmt);
     if (err >= 0) {

--- a/ext/v4l2/camera.c
+++ b/ext/v4l2/camera.c
@@ -61,7 +61,7 @@
 #define ST_STOPPING               (6)
 #define ST_FINALIZED              (7)
 
-static int xioctl(int fh, int request, void *arg)
+static int xioctl(int fh, unsigned long request, void *arg)
 {
   int r;
 

--- a/ext/v4l2/camera.h
+++ b/ext/v4l2/camera.h
@@ -23,7 +23,11 @@
 #include <pthread.h>
 #endif /* !defined(RUBY_EXTLIB) */
 
+#ifdef __OpenBSD__
+#include <sys/videoio.h>
+#else
 #include <linux/videodev2.h>
+#endif
 
 #define MAX_PLANE           3
 
@@ -68,13 +72,13 @@ typedef struct __camera__ {
 #ifndef V4L2_CTRL_TYPE_INTEGER_MENU
 #define V4L2_CTRL_TYPE_INTEGER_MENU     9
 struct __v4l2_querymenu_substitute_ {
-  __u32   id;
-  __u32   index;
+  uint32_t  id;
+  uint32_t  index;
   union {
-    __u8    name[32];
-    __s64   value;
+    uint8_t name[32];
+    int64_t value;
   };
-  __u32   reserved;
+  uint32_t  reserved;
 }  __attribute__ ((packed));
 
 #define v4l2_querymenu  __v4l2_querymenu_substitute_


### PR DESCRIPTION
This gets the module compiling on OpenBSD.  I also switched to `V4L2_FIELD_ANY` instead of forcing `V4L2_FIELD_INTERLACED` since it seems like a more reasonable default.